### PR TITLE
Use cron_d LWRP instead of cron

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ version          '0.1.2'
   supports os
 end
 
-%w(apt poise-python).each do |ckbk|
+%w(apt poise-python cron).each do |ckbk|
   depends ckbk
 end
 

--- a/resources/action.rb
+++ b/resources/action.rb
@@ -30,7 +30,7 @@ action :create do
   end
 
   curator_args = "--config #{node['elasticsearch-curator']['config_file_path']}/curator.yml #{path}/#{name}.yml"
-  cr = cron "curator-#{name}" do
+  cr = cron_d "curator" do
     command "/usr/local/bin/curator #{curator_args}"
     user    new_resource.username
     minute  new_resource.minute


### PR DESCRIPTION
Small improvement for a better cronjob management :-)

https://docs.chef.io/resource_cron.html

> The cron resource should only be used to modify an entry in a crontab file. Use the cookbook_file or template resources to add a crontab file to the cron.d directory. The cron_d lightweight resource (found in the cron cookbook) is another option for managing crontab files.
