### PR TITLE
externalize http_auth retrieval in curator config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ elasticsearch_curator_config 'default' do
   action :configure
 end
 ```
+This method also supports a http_auth property to allow passing a string with this format : "username:password". This allows retrieving the credentials from the wrapper cookbook (for example using chef-vault) and not store this sensitive information in the attributes.
 
 #### elasticsearch_curator_action
 

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -10,7 +10,7 @@ property :name, String, name_property: true
 property :config, Hash, default: {}
 property :username, String, default: node['elasticsearch-curator']['username']
 property :path, String, default: node['elasticsearch-curator']['config_file_path']
-
+property :http_auth, String, default: nil
 default_action :configure
 
 action :configure do
@@ -34,7 +34,11 @@ action :configure do
   end
 
   require 'yaml'
-
+  
+  if !http_auth.nil? and http_auth.length > 2 and http_auth.include? ':'
+    config['client']['http_auth']=http_auth
+  end
+      
   file "#{path}/curator.yml" do
     content YAML.dump(config.to_hash)
     user user

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -34,13 +34,13 @@ action :configure do
   end
 
   require 'yaml'
-  
+
   curatorconfig = config.to_hash.clone
-  
-  if !http_auth.nil? and http_auth.length > 2 and http_auth.include? ':'
-	curatorconfig['client']['http_auth']=http_auth
+
+  if !http_auth.nil? && http_auth.length > 2 && http_auth.include?(':')
+    curatorconfig['client']['http_auth'] = http_auth
   end
-      
+
   file "#{path}/curator.yml" do
     content YAML.dump(curatorconfig.to_hash)
     user user

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -35,12 +35,14 @@ action :configure do
 
   require 'yaml'
   
+  curatorconfig = config.to_hash.clone
+  
   if !http_auth.nil? and http_auth.length > 2 and http_auth.include? ':'
-    config['client']['http_auth']=http_auth
+	curatorconfig['client']['http_auth']=http_auth
   end
       
   file "#{path}/curator.yml" do
-    content YAML.dump(config.to_hash)
+    content YAML.dump(curatorconfig.to_hash)
     user user
     mode '0644'
   end


### PR DESCRIPTION
This is a PR to add support for an http_auth property to allow passing a string with this format : "username:password" in the config lwrp.
This allows retrieving the credentials from the wrapper cookbook (for example using chef-vault) and not store this sensitive information in the attributes.