### PR TITLE
Stricter permissions on the curator config

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -42,6 +42,7 @@ action :configure do
   file "#{path}/curator.yml" do
     content YAML.dump(curatorconfig.to_hash)
     user user
-    mode '0644'
+    mode '0400'
+    sensitive true
   end
 end


### PR DESCRIPTION
This PR sets stricter permissions on the curator config to make it only readable by the owner + treats the resource as sensitive, so does not expose http auth credentials in Chef client logs.

Fixes #7.