### PR TITLE
fix user permissions for curator file

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -41,7 +41,7 @@ action :configure do
 
   file "#{path}/curator.yml" do
     content YAML.dump(curatorconfig.to_hash)
-    user user
+    user new_resource.username
     mode '0400'
     sensitive true
   end


### PR DESCRIPTION
After the change in file permissions, the user now needs to be set appropriately. Setting username doesn't get used though because the file currently uses 'user' vs 'username'