### PR TITLE
Support curator v5

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -25,6 +25,9 @@ platforms:
     driver:
       image: ubuntu:16.04
       pid_one_command: /bin/systemd
+    run_list:
+      - recipe[apt]
+      - recipe[cron]
     attributes:
       apt:
         confd:
@@ -32,8 +35,11 @@ platforms:
 
   - name: centos-6
     driver:
-      image: centos:6.8
+      image: centos:6
       pid_one_command: /sbin/init
+      platform: rhel
+      intermediate_instructions:
+      - RUN yum -y install initscripts
     run_list:
       - recipe[cron]
       - recipe[yum-epel]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,14 +7,14 @@ provisioner:
   require_chef_omnibus:  <%= ENV['CHEF_VERSION'] || 'current' %>
 
 platforms:
-  - name: ubuntu-14.04
+  - name: ubuntu-16.04
     run_list:
       - recipe[apt]
-  - name: centos-7.2
+  - name: centos-7
     run_list:
       - recipe[yum-epel]
       - recipe[yum]
-  - name: centos-6.8
+  - name: centos-6
     run_list:
       - recipe[yum-epel]
       - recipe[yum]
@@ -31,11 +31,21 @@ suites:
       inspec_tests:
         - path: test/integration/default
     driver:
-      chef_version: 12.21.3
+      chef_version: 12.22.5
     attributes:
   - name: default13
     driver:
-      chef_version: 13.2.20
+      chef_version: 13.9.4
+    run_list:
+      - recipe[elasticsearch-curator::default]
+      - recipe[elasticsearch-curator-test::default]
+    verifier:
+      inspec_tests:
+        - path: test/integration/default
+    attributes:
+  - name: default14
+    driver:
+      chef_version: 14.2.0
     run_list:
       - recipe[elasticsearch-curator::default]
       - recipe[elasticsearch-curator-test::default]
@@ -45,7 +55,7 @@ suites:
     attributes:
   - name: pip_install12
     driver:
-      chef_version: 12.21.3
+      chef_version: 12.22.5
     run_list:
       - recipe[elasticsearch-curator::default]
       - recipe[elasticsearch-curator-test::default]
@@ -57,7 +67,19 @@ suites:
         install_method: 'pip'
   - name: pip_install13
     driver:
-      chef_version: 13.2.20
+      chef_version: 13.9.4
+    run_list:
+      - recipe[elasticsearch-curator::default]
+      - recipe[elasticsearch-curator-test::default]
+    verifier:
+      inspec_tests:
+        - path: test/integration/pip_install
+    attributes:
+      elasticsearch-curator:
+        install_method: 'pip'
+  - name: pip_install14
+    driver:
+      chef_version: 14.2.0
     run_list:
       - recipe[elasticsearch-curator::default]
       - recipe[elasticsearch-curator-test::default]

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
     sources:
       - chef-stable-trusty
     packages:
-      - chefdk=2.1.11-1
+      - chefdk=3.0.36-1
 
 language: ruby
 cache:
@@ -24,17 +24,29 @@ services: docker
 env:
   matrix:
     - INSTANCE=default12-ubuntu-14
+    - INSTANCE=default12-ubuntu-16
     - INSTANCE=default12-centos-6
     - INSTANCE=default12-centos-7
     - INSTANCE=pip-install12-ubuntu-14
+    - INSTANCE=pip-install12-ubuntu-16
     - INSTANCE=pip-install12-centos-6
     - INSTANCE=pip-install12-centos-7
     - INSTANCE=default13-ubuntu-14
+    - INSTANCE=default13-ubuntu-16
     - INSTANCE=default13-centos-6
     - INSTANCE=default13-centos-7
     - INSTANCE=pip-install13-ubuntu-14
+    - INSTANCE=pip-install13-ubuntu-16
     - INSTANCE=pip-install13-centos-6
     - INSTANCE=pip-install13-centos-7
+    - INSTANCE=default14-ubuntu-14
+    - INSTANCE=default14-ubuntu-16
+    - INSTANCE=default14-centos-6
+    - INSTANCE=default14-centos-7
+    - INSTANCE=pip-install14-ubuntu-14
+    - INSTANCE=pip-install14-ubuntu-16
+    - INSTANCE=pip-install14-centos-6
+    - INSTANCE=pip-install14-centos-7
 
 script:
   - chef exec cookstyle
@@ -48,17 +60,29 @@ before_script:
 matrix:
   allow_failures:
     - env: INSTANCE=default12-ubuntu-14
+    - env: INSTANCE=default12-ubuntu-16
     - env: INSTANCE=default12-centos-6
     - env: INSTANCE=default12-centos-7
     - env: INSTANCE=pip-install12-ubuntu-14
+    - env: INSTANCE=pip-install12-ubuntu-16
     - env: INSTANCE=pip-install12-centos-6
     - env: INSTANCE=pip-install12-centos-7
     - env: INSTANCE=default13-ubuntu-14
+    - env: INSTANCE=default13-ubuntu-16
     - env: INSTANCE=default13-centos-6
     - env: INSTANCE=default13-centos-7
     - env: INSTANCE=pip-install13-ubuntu-14
+    - env: INSTANCE=pip-install13-ubuntu-16
     - env: INSTANCE=pip-install13-centos-6
     - env: INSTANCE=pip-install13-centos-7
+    - env: INSTANCE=default14-ubuntu-14
+    - env: INSTANCE=default14-ubuntu-16
+    - env: INSTANCE=default14-centos-6
+    - env: INSTANCE=default14-centos-7
+    - env: INSTANCE=pip-install14-ubuntu-14
+    - env: INSTANCE=pip-install14-ubuntu-16
+    - env: INSTANCE=pip-install14-centos-6
+    - env: INSTANCE=pip-install14-centos-7
   include:
     - script:
       - chef exec cookstyle

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,13 +2,13 @@ default['elasticsearch-curator']['version'] = nil
 default['elasticsearch-curator']['install_method'] = 'package'
 case node['platform_family']
 when 'debian'
-  default['elasticsearch-curator']['repository_url'] = 'http://packages.elastic.co/curator/4/debian'
+  default['elasticsearch-curator']['repository_url'] = 'http://packages.elastic.co/curator/5/debian'
 when 'rhel'
   default['elasticsearch-curator']['repository_url'] = case node['platform_version'].to_i
                                                        when 6
-                                                         'http://packages.elastic.co/curator/4/centos/6'
+                                                         'http://packages.elastic.co/curator/5/centos/6'
                                                        when 7
-                                                         'http://packages.elastic.co/curator/4/centos/7'
+                                                         'http://packages.elastic.co/curator/5/centos/7'
                                                        end
 end
 default['elasticsearch-curator']['repository_key'] = 'https://packages.elastic.co/GPG-KEY-elasticsearch'

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,9 +14,6 @@ end
   depends ckbk
 end
 
-# For compatibility with 12.X versions of Chef
-depends 'compat_resource'
-
 chef_version '>= 12.9' if respond_to?(:chef_version)
 source_url 'https://github.com/cyberflow/chef-elasticsearch-curator' if respond_to?(:source_url)
 issues_url 'https://github.com/cyberflow/chef-elasticsearch-curator/issues' if respond_to?(:issues_url)

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -34,9 +34,7 @@ action :configure do
 
   curatorconfig = new_resource.config.to_hash.clone
 
-  if !new_resource.http_auth.nil? && new_resource.http_auth.length > 2 && new_resource.http_auth.include?(':')
-    curatorconfig['client']['http_auth'] = new_resource.http_auth
-  end
+  curatorconfig['client']['http_auth'] = new_resource.http_auth if new_resource.http_auth && new_resource.http_auth.length > 2 && new_resource.http_auth.include?(':')
 
   file "#{new_resource.path}/curator.yml" do
     content YAML.dump(curatorconfig.to_hash)

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -6,10 +6,10 @@
 # Copyright 2016 Servers.com
 #
 
-property :arch_type, kind_of: String
-property :install_method, kind_of: String, default: 'package'
-property :repository_url, kind_of: String, default: node['elasticsearch-curator']['repository_url']
-property :repository_key, kind_of: String, default: node['elasticsearch-curator']['repository_key']
+property :arch_type, String
+property :install_method, String, default: 'package'
+property :repository_url, String, default: node['elasticsearch-curator']['repository_url']
+property :repository_key, String, default: node['elasticsearch-curator']['repository_key']
 property :install_version, [String, nil],  default: nil
 default_action :install
 
@@ -44,6 +44,7 @@ action :install do
   elsif new_resource.install_method == 'pip'
     package 'python-pip'
     node.override['poise-python']['provider'] = 'system'
+    node.override['poise-python']['provider'] = 'scl' if platform_family?('rhel')
     @run_context.include_recipe 'poise-python::default'
     python_virtualenv '/opt/elasticsearch-curator'
     python_package 'elasticsearch-curator' do

--- a/test/integration/pip_install/controls/default.rb
+++ b/test/integration/pip_install/controls/default.rb
@@ -11,10 +11,9 @@ control 'elasticsearch_curator_pip' do
     describe package('python2-pip') do
       it { should be_installed }
     end
-  end
-
-  describe package('python-setuptools') do
-    it { should be_installed }
+    describe package('python-setuptools') do
+      it { should be_installed }
+    end
   end
 
   describe file('/home/curator/.curator/curator.yml') do
@@ -58,11 +57,5 @@ control 'elasticsearch_curator_pip' do
 
   describe file('/opt/elasticsearch-curator') do
     it { should be_directory }
-  end
-
-  if os[:family] == 'debian'
-    describe package('python-pkg-resources') do
-      it { should be_installed }
-    end
   end
 end


### PR DESCRIPTION
This is to install curator v5 instead of v4 with some modification to the travis-ci to have a working build on all platform.
I also added chef14 tests and ubuntu 16.
