### PR TITLE
Add kitchen-inspec to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 group :integration do
   gem 'berkshelf'
+  gem 'kitchen-inspec'
   gem 'kitchen-transport-rsync'
   gem 'kitchen-vagrant'
   gem 'test-kitchen'


### PR DESCRIPTION
Required for test-kitchen to run with `bundle exec`. Without this being added to the Gemfile, I get the following error:

```
$ bundle exec kitchen list
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ClientError
>>>>>> Message: Could not load the 'inspec' verifier from the load path. Did you mean: busser, dummy, shell ? Please ensure that your verifier is installed as a gem or included in your Gemfile if using Bundler.
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```
